### PR TITLE
Issue #6: making keywords case-insensitive

### DIFF
--- a/PlantUml.xml
+++ b/PlantUml.xml
@@ -1,7 +1,7 @@
 <NotepadPlus>
     <UserLang name="PlantUML" ext="" udlVersion="2.1">
         <Settings>
-            <Global caseIgnored="no" allowFoldOfComments="no" foldCompact="no" forcePureLC="0" decimalSeparator="0" />
+            <Global caseIgnored="yes" allowFoldOfComments="no" foldCompact="no" forcePureLC="0" decimalSeparator="0" />
             <Prefix Keywords1="no" Keywords2="no" Keywords3="yes" Keywords4="yes" Keywords5="yes" Keywords6="no" Keywords7="no" Keywords8="yes" />
         </Settings>
         <KeywordLists>


### PR DESCRIPTION
Because that's what they are in PlantUML.  In this way users of PlantUML and this Notepad++ syntax highlighter do not need to change their PlantUML code to match the case defined in the UDL.